### PR TITLE
Fix for ssl cert error

### DIFF
--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import webbrowser
 
+from boto.s3.connection import OrdinaryCallingFormat
 from distutils.spawn import find_executable
 from fabric.api import local, prompt, require, settings, task
 from fabric.state import env
@@ -213,7 +214,7 @@ def _check_slug(slug):
         return True
 
     try:
-        s3 = boto.connect_s3()
+        s3 = boto.connect_s3(calling_format=OrdinaryCallingFormat())
         bucket = s3.get_bucket(app_config.PRODUCTION_S3_BUCKET['bucket_name'])
         key = bucket.get_key('%s/graphics/%s/child.html' % (app_config.PROJECT_SLUG, slug))
 

--- a/fabfile/flat.py
+++ b/fabfile/flat.py
@@ -10,6 +10,7 @@ import os
 
 import boto
 from boto.s3.key import Key
+from boto.s3.connection import OrdinaryCallingFormat
 
 import app_config
 
@@ -109,7 +110,7 @@ def deploy_folder(src, dst, headers={}, ignore=[]):
 
             to_deploy.append((src_path, dst_path))
 
-    s3 = boto.connect_s3()
+    s3 = boto.connect_s3(calling_format=OrdinaryCallingFormat())
 
     for src, dst in to_deploy:
         deploy_file(s3, src, dst, headers)


### PR DESCRIPTION
I was getting a ssl certificate error when creating a new graphic.

    ssl.CertificateError: hostname 'apps.stlpublicradio.org.s3.amazonaws.com' doesn't match either of '*.s3.amazonaws.com', 's3.amazonaws.com'

I found this discussion on the repo for boto: https://github.com/boto/boto/issues/2836

The issue seems to have something to do with dots in bucket names.

Then I saw a fix Joe Germuska had made to StoryMapJS: https://github.com/NUKnightLab/StoryMapJS/commit/908e2bd0f718cd3714fdcc197c8cb8abd267541f

I made this change and it works for me now. Providing it here in case it's useful to someone else.