### PR TITLE
Changes the date format used when parsing line chart data from "%m/%d/%y" to "%Y" to match Google spreadsheet data format

### DIFF
--- a/graphic_templates/line_chart/js/graphic.js
+++ b/graphic_templates/line_chart/js/graphic.js
@@ -56,7 +56,7 @@ var loadCSV = function(url) {
  */
 var formatData = function() {
     graphicData.forEach(function(d) {
-        d['date'] = d3.time.format('%m/%d/%y').parse(d['date']);
+        d['date'] = d3.time.format('%Y').parse(d['date']);
 
         for (var key in d) {
             if (key != 'date') {


### PR DESCRIPTION
The current line chart template code expects a date with the format `%m/%d/%y`, but the template Google spreadsheet contains four-digit years in the date field (`%Y`). This causes D3 to fail when parsing the date, and the chart won't render as a result.