### PR TITLE
Add carebot scroll depth tracker

### DIFF
--- a/graphic_templates/_base/js/analytics.js
+++ b/graphic_templates/_base/js/analytics.js
@@ -64,6 +64,15 @@ var ANALYTICS = (function () {
             eventData['eventValue'] = value
         }
 
+        // Track details about the parent with each event
+        var parentUrl = getParameterByName('parentUrl') || '';
+        var parentHostname = '';
+        if (parentUrl) {
+            parentHostname = urlToLocation(parentUrl).hostname;
+        }
+        eventData[DIMENSION_PARENT_URL] = parentUrl;
+        eventData[DIMENSION_PARENT_HOSTNAME] = parentHostname;
+        
         ga('send', eventData);
     }
 

--- a/graphic_templates/graphic/js/graphic.js
+++ b/graphic_templates/graphic/js/graphic.js
@@ -17,6 +17,9 @@ var onWindowLoaded = function() {
     pymChild.onMessage('on-screen', function(bucket) {
         ANALYTICS.trackEvent('on-screen', bucket);
     });
+    pymChild.onMessage('scroll-depth', function(percent) {
+        ANALYTICS.trackEvent('scroll-depth', percent);
+    });
 }
 
 /*

--- a/templates/parent.html
+++ b/templates/parent.html
@@ -231,9 +231,14 @@
                 require_{{ var_name }} = null;
             })
 
-            // Add Carebot tracker
-            var tracker = new CarebotTracker.VisibilityTracker('responsive-embed-{{ slug }}', function(result) {
+            // Add Carebot linger time tracker
+            var lingerTracker = new CarebotTracker.VisibilityTracker('responsive-embed-{{ slug }}', function(result) {
               pymParent.sendMessage('on-screen', result.bucket);
+            });
+
+            // Add Carebot scroll depth tracker
+            var scrollTracker = new CarebotTracker.ScrollTracker('storytext', function(percent) {
+              pymParent.sendMessage('scroll-depth', percent);
             });
         });
     // Require.js is not on the page, but jQuery is (old Seamus)


### PR DESCRIPTION
Adds a tracker that reports how deep into an article users read, in 10% increments. 

Adding the tracker looks like this:
```
            // Add Carebot scroll depth tracker
            var scrollTracker = new CarebotTracker.ScrollTracker('storytext', function(percent) {
              pymParent.sendMessage('scroll-depth', percent);
            });
```

The open question is: should we report this per slug, or should we report this stat to the main NPR analytics property? 

If it should be to the slug, I can go through and add the event listener to each of the graphic's js. 

If it's to the NPR property, I'll need to update the PR to add the tracking code to `parent.html`.

