### PR TITLE
Fix a typo on map that gave blank events for scroll depth

### DIFF
--- a/graphic_templates/locator_map/js/graphic.js
+++ b/graphic_templates/locator_map/js/graphic.js
@@ -58,8 +58,8 @@ var loadJSON = function() {
         pymChild.onMessage('on-screen', function(bucket) {
             ANALYTICS.trackEvent('on-screen', bucket);
         });
-        pymChild.onMessage('scroll-depth', function(percent) {
-            ANALYTICS.trackEvent('scroll-depth', percent);
+        pymChild.onMessage('scroll-depth', function(data) {
+            ANALYTICS.trackEvent('scroll-depth', data.percent, data.seconds);
         });
     });
 }


### PR DESCRIPTION
I missed switching one graphic over to the current recording format. 