### PR TITLE
Remove previously loaded graphic_config module before loading a new one.

### DIFF
--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -175,6 +175,7 @@ def update_copy(slug=None):
 
         print slug
         download_copy(slug)
+        del sys.modules['graphic_config']
 
 
 """


### PR DESCRIPTION
Otherwise, missing fields like the COPY_GOOGLE_DOC_KEY will persist from the previous graphic config. The checks against whether those fields exist will fail, and the data from the previous graphic will be loaded into the current one.

Note that this is only an issue when update_copy is called with no arguments and some of the graphics lack a defined COPY_GOOGLE_DOC_KEY.

There's probably a more elegant way to do this, but it was sufficient for my needs.
