### PR TITLE
Add fonts as mixins to base.less

### DIFF
--- a/graphic_templates/_base/css/base.less
+++ b/graphic_templates/_base/css/base.less
@@ -47,7 +47,7 @@
 
 // Normal Knockout
 .knockout() {
-    font-family: 'Knockout 31 4r';
+    font-family: 'Knockout 31 4r','Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
     font-weight: normal;
 }
 

--- a/graphic_templates/_base/css/base.less
+++ b/graphic_templates/_base/css/base.less
@@ -53,6 +53,8 @@
 .knockout-upper() {
     .knockout();
     text-transform: uppercase;
+    letter-spacing: 0.05em;
+    -webkit-font-smoothing: antialiased;
 }
 
 .sans-serif() {

--- a/graphic_templates/_base/css/base.less
+++ b/graphic_templates/_base/css/base.less
@@ -37,6 +37,29 @@
 @blue6      : #D3EAF7;
 
 /*
+ * Fonts
+ */
+.gotham() {
+    font-family: 'Gotham SSm',Helvetica,Arial,sans-serif;
+    font-weight: normal;
+    font-weight: 400;
+}
+
+.knockout() {
+    font-family: 'Knockout 31 4r';
+    font-weight: normal;
+}
+
+.knockout-upper() {
+    .knockout();
+    text-transform: uppercase;
+}
+
+.sans-serif() {
+    font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+}
+
+/*
  * Mixins
  */
 .clearfix() {

--- a/graphic_templates/_base/css/base.less
+++ b/graphic_templates/_base/css/base.less
@@ -45,14 +45,21 @@
     font-weight: 400;
 }
 
+// Normal Knockout
 .knockout() {
     font-family: 'Knockout 31 4r';
     font-weight: normal;
 }
 
+// Knockout, uppercased
 .knockout-upper() {
     .knockout();
     text-transform: uppercase;
+}
+
+// Knockout for headings
+.knockout-header() {
+    .knockout-upper();
     letter-spacing: 0.05em;
     -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
Tested this, all variables referenced correctly. The Knockout stuff is a little funny -- I think it helps to have just the standard font reference, but since our Knockout headers have some letter-spacing to clean it up, I added it as a separate variable. Too weird?