### PR TITLE
Adds numeric scale option to hexmap legend

### DIFF
--- a/graphic_templates/_base/js/helpers.js
+++ b/graphic_templates/_base/js/helpers.js
@@ -161,3 +161,12 @@ var isProduction = function(u) {
     }
     return result;
 }
+
+/*
+ * Polyfill for String.trim()
+ */
+if (!String.prototype.trim) {
+    String.prototype.trim = function () {
+        return this.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
+    };
+}

--- a/graphic_templates/state_grid_map/child_template.html
+++ b/graphic_templates/state_grid_map/child_template.html
@@ -22,7 +22,12 @@
     </div>
 
     <div id="map-template" style="display: none;">
-        <ul class="key"></ul>
+        <div class="key-wrap">
+            {% if COPY.labels.legend_head %}
+            <h3>{{ COPY.labels.legend_head }}</h3>
+            {% endif %}
+            <ul class="key"></ul>
+        </div>
 
         <?xml version="1.0" encoding="UTF-8" standalone="no"?>
         <svg viewBox="0 0 436 254" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">

--- a/graphic_templates/state_grid_map/child_template.html
+++ b/graphic_templates/state_grid_map/child_template.html
@@ -95,6 +95,7 @@
     </div>
 
     <script type="text/javascript">
+        var LABELS = {{ COPY['labels'].json() }};
         var DATA = {{ COPY['data'].json() }};
         var STATES = {{ COPY['states'].json() }};
     </script>

--- a/graphic_templates/state_grid_map/css/graphic.less
+++ b/graphic_templates/state_grid_map/css/graphic.less
@@ -58,7 +58,7 @@
 
                 &.end-label {
                     left: auto;
-                    right: -35%;
+                    right: -25%;
                 }
             }
         }

--- a/graphic_templates/state_grid_map/css/graphic.less
+++ b/graphic_templates/state_grid_map/css/graphic.less
@@ -2,30 +2,67 @@
 
 /* Key
 ========================================*/
-.key {
-    margin: 0 0 18px 0;
-    padding: 0;
-    list-style-type: none;
-}
-.key .key-item {
-    display: inline-block;
-    margin: 0 18px 0 0;
-    padding: 0;
-    line-height: 15px;
-}
-.key .key-item b {
-    display: inline-block;
-    width: 15px;
-    height: 15px;
-    margin-right: 6px;
-    float: left;
-}
-.key .key-item label {
-    white-space: nowrap;
-    font-size: 12px;
-    color: #666;
-    font-weight: normal;
-    -webkit-font-smoothing: antialiased;
+.key-wrap {
+    .key {
+        margin: 0 0 18px 0;
+        padding: 0;
+        list-style-type: none;
+
+        .key-item {
+            display: inline-block;
+            margin: 0 18px 0 0;
+            padding: 0;
+            line-height: 15px;
+        }
+        .key-item b {
+            display: inline-block;
+            width: 15px;
+            height: 15px;
+            margin-right: 6px;
+            float: left;
+        }
+        .key-item label {
+            white-space: nowrap;
+            font-size: 12px;
+            color: #666;
+            font-weight: normal;
+            -webkit-font-smoothing: antialiased;
+        }
+    }
+
+    // Numeric scale style
+    &.numeric-scale {
+        width: 100%;
+        text-align: center;
+
+        h3 {
+            margin-bottom: 5px;
+        }
+
+        .key {
+            .key-item {
+                margin: 0 1px 0 0;
+                position: relative;
+            }
+
+            .key-item b {
+                width: 45px;
+                height: 10px;
+                margin-right: 0;
+            }
+
+            .key-item label {
+                position: absolute;
+                bottom: -20px;
+                left: -15%;
+
+                &.end-label {
+                    left: auto;
+                    right: -35%;
+                }
+            }
+        }
+    }
 }
 
 /* Grid Map

--- a/graphic_templates/state_grid_map/js/graphic.js
+++ b/graphic_templates/state_grid_map/js/graphic.js
@@ -44,7 +44,9 @@ var render = function(containerWidth) {
     renderStateGridMap({
         container: '#state-grid-map',
         width: containerWidth,
-        data: DATA
+        data: DATA,
+        // isNumeric will style the legend as a numeric scale
+        isNumeric: true
     });
 
     // Update iframe
@@ -79,13 +81,22 @@ var renderStateGridMap = function(config) {
 
     categories = d3.set(categories).values().sort();
 
-    // Define color scale
-    var colorScale = d3.scale.ordinal()
-        .domain(categories)
-        .range([COLORS['red3'], COLORS['yellow3'], COLORS['blue3'], COLORS['orange3'], COLORS['teal3']]);
-
     // Create legend
+    var legendWrapper = containerElement.select('.key-wrap');
     var legendElement = containerElement.select('.key');
+
+    if (config['isNumeric']) {
+        legendWrapper.classed('numeric-scale', true);
+
+        var colorScale = d3.scale.ordinal()
+            .domain(categories)
+            .range([COLORS['teal6'], COLORS['teal5'], COLORS['teal4'], COLORS['teal3'], COLORS['teal2'], COLORS['teal1']]);
+    } else {
+        // Define color scale
+        var colorScale = d3.scale.ordinal()
+            .domain(categories)
+            .range([COLORS['red3'], COLORS['yellow3'], COLORS['blue3'], COLORS['orange3'], COLORS['teal3']]);
+    }
 
     _.each(colorScale.domain(), function(key, i) {
         var keyItem = legendElement.append('li')

--- a/graphic_templates/state_grid_map/js/graphic.js
+++ b/graphic_templates/state_grid_map/js/graphic.js
@@ -40,13 +40,21 @@ var render = function(containerWidth) {
         isMobile = false;
     }
 
+    console.log(LABELS);
+
+    if (LABELS['is_numeric'] && LABELS['is_numeric'].toLowerCase() == 'true') {
+        var isNumeric = true;
+    } else {
+        var isNumeric = false;
+    }
+
     // Render the map!
     renderStateGridMap({
         container: '#state-grid-map',
         width: containerWidth,
         data: DATA,
         // isNumeric will style the legend as a numeric scale
-        isNumeric: true
+        isNumeric: isNumeric
     });
 
     // Update iframe
@@ -73,13 +81,24 @@ var renderStateGridMap = function(config) {
     // Extract categories from data
     var categories = [];
 
-    _.each(config['data'], function(state) {
-        if (state[valueColumn] != null) {
-            categories.push(state[valueColumn]);
-        }
-    });
+    if (LABELS['legend_labels'] && LABELS['legend_labels'] !== '') {
+        // If custom legend labels are specified
+        var legendLabels = LABELS['legend_labels'].split(',');
+        _.each(legendLabels, function(label) {
+            categories.push(label.trim());
+        });
+    } else {
+        // Default: Return sorted array of categories
+         _.each(config['data'], function(state) {
+            if (state[valueColumn] != null) {
+                categories.push(state[valueColumn]);
+            }
+        });
 
-    categories = d3.set(categories).values().sort();
+        categories = d3.set(categories).values().sort();
+    }
+
+    console.log(categories);
 
     // Create legend
     var legendWrapper = containerElement.select('.key-wrap');

--- a/graphic_templates/state_grid_map/js/graphic.js
+++ b/graphic_templates/state_grid_map/js/graphic.js
@@ -140,9 +140,10 @@ var renderStateGridMap = function(config) {
     _.each(config['data'], function(state) {
         if (state[valueColumn] !== null) {
             var stateClass = 'state-' + classify(state['state_name']);
+            var categoryClass = 'category-' + classify(state[valueColumn]);
 
             chartElement.select('.' + stateClass)
-                .attr('class', stateClass + ' state-active')
+                .attr('class', stateClass + ' state-active ' + categoryClass)
                 .attr('fill', colorScale(state[valueColumn]));
         }
     });
@@ -159,7 +160,7 @@ var renderStateGridMap = function(config) {
                 return isMobile ? state['usps'] : state['ap'];
             })
             .attr('class', function(d) {
-                return d[valueColumn] !== null ? 'label label-active' : 'label';
+                return d[valueColumn] !== null ? 'category-' + classify(d[valueColumn]) + ' label label-active' : 'label';
             })
             .attr('x', function(d) {
                 var className = '.state-' + classify(d['state_name']);

--- a/graphic_templates/state_grid_map/js/graphic.js
+++ b/graphic_templates/state_grid_map/js/graphic.js
@@ -40,8 +40,6 @@ var render = function(containerWidth) {
         isMobile = false;
     }
 
-    console.log(LABELS);
-
     if (LABELS['is_numeric'] && LABELS['is_numeric'].toLowerCase() == 'true') {
         var isNumeric = true;
     } else {
@@ -98,8 +96,6 @@ var renderStateGridMap = function(config) {
         categories = d3.set(categories).values().sort();
     }
 
-    console.log(categories);
-
     // Create legend
     var legendWrapper = containerElement.select('.key-wrap');
     var legendElement = containerElement.select('.key');
@@ -126,6 +122,15 @@ var renderStateGridMap = function(config) {
 
         keyItem.append('label')
             .text(key);
+
+        // Add the optional upper bound label on numeric scale
+        if (config['isNumeric'] && i == categories.length - 1) {
+            if (LABELS['max_label'] && LABELS['max_label'] !== '') {
+                keyItem.append('label')
+                    .attr('class', 'end-label')
+                    .text(LABELS['max_label']);
+            }
+        }
     });
 
     // Select SVG element


### PR DESCRIPTION
Supports an optional numeric legend (as opposed to the standard categorical legend) with options configured in the graphic's spreadsheet. Would close #191.

Also adds: 
- An optional legend title (styled as an `h3`)
- An option in the spreadsheet to specify the order of categories
- Category classes to the hexagons and state labels (since I occasionally use that for additional CSS)
- A polyfill to `helpers.js` for `String.trim()`, which is used to trim whitespace in the custom category handling

Some of the options are a little weird, but I couldn't think of a better way to do them. Feedback is welcome! Ideally, any major options would stay in the same place -- which is why I tried to do them all in the spreadsheet.

![image](https://cloud.githubusercontent.com/assets/969843/21662350/3999a084-d2a7-11e6-89db-4edaebd4be51.png)