### PR TITLE
Make textarea responsive to avoid horizontal overflow on small screens

### DIFF
--- a/templates/parent.html
+++ b/templates/parent.html
@@ -122,6 +122,9 @@
         textarea {
             display: block;
             margin-bottom: 5px;
+            width: 100%;
+            max-width: 500px;
+            box-sizing: border-box;
         }
 
         .segment-group{


### PR DESCRIPTION
Just a few lines of CSS to make the textarea with embed code resize responsively. On small screens, the textarea overflows the browser, causing the whole window to scroll horizontally in a bothersome way.