### PR TITLE
Update the copyedit note template 

### DIFF
--- a/templates/copyedit/note.txt
+++ b/templates/copyedit/note.txt
@@ -1,13 +1,13 @@
 {% trans count=graphics|length %}
-This graphic accompanies [AUTHOR]'s story, running [TIME], about [SUBJECT].
+This graphic accompanies __AUTHOR__'s story, running __TIME__, about __SUBJECT__.
 {% pluralize %}
-These graphics accompany [AUTHOR]'s story, running [TIME], about [SUBJECT].
+These graphics accompany __AUTHOR__'s story, running __TIME__, about __SUBJECT__.
 {% endtrans %}
-Story URL (not yet published): http://seamus.npr.org/templates/story/story.php?storyId=[SEAMUS_ID]&live=1
+Story URL (not yet published): http://seamus.npr.org/templates/story/story.php?storyId=__SEAMUS_ID__&live=1
 
-Expected run date: [TIME]
+Expected run date: __TIME__
 
-Primary graphics contact: [GRAPHICS_CONTACT]
-Primary editorial contact: [EDITORIAL_CONTACT]
+Primary graphics contact: __GRAPHICS_CONTACT__
+Primary editorial contact: __EDITORIAL_CONTACT__
 
 {% for graphic in graphics %}{% include 'copyedit/graphic.txt' %}{% endfor %}


### PR DESCRIPTION
Using underscores instead of brackets makes substituting information more efficient. 