### PR TITLE
Upgrade Fabric and gunicorn to avoid final current security bugs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 Authomatic==0.1.0.post1
-Fabric==1.13.1
+Fabric==1.14.0
 Flask==0.9
 boto==2.48.0
 copytext==0.1.9
 cssmin==0.2.0
 docutils==0.11
-gunicorn==19.1.1
+gunicorn==19.8.1
 requests==2.18.4
 slimit==0.8.1
 ply==3.4


### PR DESCRIPTION
Patches two remaining security bugs that Snyk is complaining about. No change to the APIs for those two libraries; I did a quick check to make sure some of the `fab` commands were still working well on my local machine.